### PR TITLE
Add documentation after nextjs removal

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -1,5 +1,5 @@
 ---
-id: architecture_api
+id: api-architecture
 sidebar_position: 2
 title: API Architecture
 ---

--- a/docs/architecture/basics.md
+++ b/docs/architecture/basics.md
@@ -6,10 +6,11 @@ title: Basics
 
 # Architecture Overview
 
-We are using a three tier architecture consisting of a presentation layer (NextJs Application), 
+We are using a three tier architecture consisting of a presentation layer (statically-built React Application), 
 business layer (NestJs Application) and a persistence layer (PostgreSql database). 
 Each of the layers is hosted on a different Google Service (for details see [Infrastructure](../infrastructure/basics))
-and has it's own update cycle. 
+and has it's own update cycle.
+
 
 ```mermaid
 graph TD;

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -1,0 +1,142 @@
+---
+id: frontend-architecture
+sidebar_position: 3
+title: Frontend Architecture
+---
+
+# Architecture Overview
+
+Since we're using React, there is no clear-cut MVC structure such as with Angular. In recent version, React fully
+embraces the functional paradigm in
+recommending [functional components](https://reactjs.org/docs/components-and-props.html#function-and-class-components)
+and using the powerful [hooks](https://reactjs.org/docs/hooks-intro.html). However, we still decided to have some kind
+of structure to increase readability and maintainability.
+
+:::info Where is next.js!?
+
+Initially, the project started with [next.js](https://nextjs.org/). However, we came to realize that it was the wrong
+tool for our project and added unnecessary overhead. The decision was taken in agreement with Tobias
+during [development meeting 4](/meeting-notes/development-meeting-4). The main work was done
+in [merge request #36](https://github.com/gipfeli-io/gipfeli-frontend/pull/36). For those interested, the last version
+using next.js can be found in the
+[`deprecated/nextjs-base`](https://github.com/gipfeli-io/gipfeli-frontend/tree/deprecated/nextjs-base) branch.
+
+:::
+
+```plantuml Overall
+@startuml
+
+[Hooks] ..> [Contexts]
+
+package "Components" {
+  [Providers] ..> [Contexts]
+  ReactRouter - [Pages]
+  [ReactComponents] ..> [Hooks]
+  [Pages] ..> [ReactComponents]
+  [Pages] ..> [Hooks]
+}
+[Services]
+
+[Providers] ..> [Services]
+[ReactComponents] ..> [Services]
+
+
+@enduml
+```
+
+The above components are the essential building blocks of our frontend.
+
+## General
+
+A React app consists of a tree of components. The actual components are rendered depending on the current state of the
+application. In order to be able to handle routing, we are using the  [ReactRouter](https://reactrouter.com/) library.
+This application consists of components that are used to define which components should be rendered when a user accesses
+a given page. As such, this library can be seen as something like the entry point to our frontend.
+
+Since ReactRouter has very powerful nesting features, it also allows to define layouts that span across multiple pages
+using its `<Outlet />` component.
+
+:::tip Example
+
+As an example, all our routes are nested within a `<Route path="/" element={<MainLayout/>}>` component, which uses
+a `<MainLayout />` component. This component defines some global stylings that apply for all pages in our app.
+:::
+
+## Components
+
+Components are React components and can be divided in 3 subgroups.
+
+### Pages
+
+`Pages` are special kinds of components that define a page that is accessible via a URL through ReactRouter. A `Page`
+handles the choice of components for its functionality as well as data fetching on a global (read: page-wide) scale. It
+uses various `ReactComponents`, both custom as well as visual ones from the Material UI library.
+
+:::tip Example
+
+The following code renders the `<Login />` page component, nested inside its `<AuthPageLayout />` and maps to the path "
+host.name/login".
+
+```jsx
+<Route path="/" element={<AuthPageLayout/>}>
+    <Route path="login" element={<Login/>}/>
+</Route>
+```
+
+:::
+
+### ReactComponents
+
+React apps are composed of subcomponents which serve display purposes and functionalities. An example is
+a `<TourForm />` component which serves as the host component for realizing our tour form. It is composed of several
+subcomponents and has different functions.
+
+They can access `Services` when they need to fetch data from sources such as an API or local storage, and they may also
+use `Hooks` (see below).
+
+### Providers
+
+These are special components since they realize
+a [ContextProvider](https://reactjs.org/docs/context.html#contextprovider). Their purpose is to wrap its children inside
+a context that provides the children with global functionalities, removing the need to pass down functional properties
+in a deeply nested component tree. See below for more information.
+
+As such, they can also use `Services` if they require things from data sources.
+
+## Hooks
+
+These are a recent React feature that allows to use things that were previously only usable in class components, such as
+state. Besides the [official hooks](https://reactjs.org/docs/hooks-reference.html), we also added custom hooks, which
+can be used by our `Components`.
+
+They can use `Services` and also reference `Contexts`
+
+## Services
+
+These are standard services that are used to fetch data from any kind of source - localstorage, API, etc.
+
+## Context
+
+A context defines an interface that is provided by a provider and consumed by a consumer. See below.
+
+## Hooks, Context and Providers explained
+
+We use these features to implement large-scale contexts. We also have smaller contexts (e.g. a `MapContext`) that are
+used within a contained environment, such as a group of components (e.g. the `Map` component). These work in a similar
+way, but can be simplified without hooks and external providers.
+
+We have the following contexts:
+
+* `ThemeContext`: Used to retrieve, set and store the user's preference for darkmode or lightmode
+* `AuthenticationContext`: Used to store the user's login state
+* `NotificationContext`: Used to display notifications that can be triggered by any component in the tree
+
+The way we implemented these features is as follows:
+
+* The `Context` defines its interface, specifying which props it has (which can be values or functions)
+* The `Provider` is an actual implementation of a `Context` which returns a `ContextProvider` with the interface
+  implementation. It wraps around all the child components it gets passed as props.
+* The `Hook` basically just returns `useContext` and can be used by components requiring the `Context`.
+
+Using this pattern, the components do not need to know anything about the implementation of the context, since that is
+delegated fully to the `Provider`. Just using the `Hook` is enough to access the `Context`.

--- a/docs/infrastructure/frontend-deployment.md
+++ b/docs/infrastructure/frontend-deployment.md
@@ -1,22 +1,46 @@
 ---
-id: frontend-deployment 
-sidebar_position: 2 
+id: frontend-deployment
+sidebar_position: 2
 title: Frontend deployment
 ---
 
-Our frontend is built with [next.js](https://nextjs.org/) and runs its own process to handle incoming requests.
+Our frontend is built with [React](https://reactjs.org/) using [Create React App](https://create-react-app.dev/) as a
+skeleton builder. Currently, the build output is served via a lightweight [Nginx](https://www.nginx.com/) webserver.
+
+:::tip Why we're using Nginx to serve a static website
+
+Given that a React app is built and only consists of static files (Javascript, CSS, HTML, etc.), there are several ways
+how these files can be served. Using Nginx is the most straightforward approach since its a basic webserver that serves
+files and it comes with all amenities such as GZIP compression, routing and so on. 
+
+However, it could become more cost-efficient to drop Cloud Run and serve the files from a simple Storage Bucket. That 
+would require a Load Balancer, though, and at the moment the costs of adding a Load Balancer are far higher than using 
+Cloud Run.
+
+:::
 
 ## Deployment steps
 
-Deployment always happens when a push is sent to main. This triggers
-the [GitHub Action](https://github.com/gipfeli-io/gipfeli-frontend/blob/stage/.github/workflows/deployment.yml) that performs
-the following steps:
+Deployment always happens when a push is sent to main or stage. This triggers
+the [GitHub Action](https://github.com/gipfeli-io/gipfeli-frontend/blob/stage/.github/workflows/ci.yml) that
+performs the following steps:
 
-1. Establish connection to our Google Cloud account using the official [google-github-actions/auth](https://github.com/google-github-actions/auth) step.
-2. After step 1, we can now use `gcloud` tools. First, we configure the container registry.
-3. At this point, we build the container image, assigning it a unique name (`gcr.io/{project_id}/{app_name}:{commit_sha}`)
-4. We push our previously built image to our registry
-5. Finally, we deploy our image to our CloudRun service. This automatically deploys our new image, starts its pod and gracefully replaces the old pod.
+1. Run all the the steps in the `test-and-build` job, consisting of
+    1. Run tests
+    2. Configure the API URL
+    3. Build the container assigning it a unique name (`gcr.io/{project_id}/{app_name}:{commit_sha}`)
+    4. If we are pushing to either `stage` or `main`:
+        1. establish connection to our Google Cloud account using the
+           official [google-github-actions/auth](https://github.com/google-github-actions/auth) step.
+        2. After step 1, we can now use `gcloud` tools. First, we configure the container registry.
+        3. We then push the image to the Google Cloud Container Registry
+2. Depending on whether we push to `stage` or `main`, we run either the `deploy-stage` or the `deploy-main` job. They do
+   the same but use different endpoints to deploy the correct environment. This takes the following steps:
+    1. Authenticate with Google Cloud again
+    2. Deploy the previously pushed image using `gcloud run deploy`
+3. After this, the deployment starts, boots up our new image, performs healthchecks and gracefully replaces the previous
+   running pod with our new pod, redirecting all traffic to this pod.
 
 ## Todo
+
 - [ ] Change link to `main` branch action when deployed to production

--- a/general/lessons-learned.md
+++ b/general/lessons-learned.md
@@ -21,12 +21,21 @@ and how we solved them or what implications they had on the project.
   rather difficult and the documentation does not provide much help. Furthermore, since the `Credentials` provider is
   disencouraged by the authors, a lot of customization has to be made. As we're using `JWT` as authentication strategy,
   it could be simpler to just build the authorization flow from scratch.
+* **Dropping next.js in favor of pure React:** The most important lesson that we learned was that next.js was the wrong
+  tool for what we had in mind. Since we are developing an application that does not require any SEO optimization, the
+  whole point of having `getServerSideProps` is void. Apart from that, we had more troubles than benefits in using
+  next.js in our setup (see above) and we found its documentation to be rather clumsy, especially with regards to the
+  typescript part. Lots of things that were easily doable with plain React required workarounds. Since one of our goals
+  was also to have an offline part, we decided it would be best to just use plain React. Because next.js is a wrapper
+  around React, we were able to create a React app from scratch and move all of our existing code to it, which worked
+  quite well.
 
 ## Backend
 
 ### nest.js
 
 * **TBD:**
+
 ## Google Cloud Platform
 
 ### General


### PR DESCRIPTION
This adjusts the documentation after the great overhaul in https://github.com/gipfeli-io/gipfeli-frontend/issues/34

Please also see the http://localhost:3000/docs/architecture/frontend-architecture stuff. I am not sure if the package diagram is correct, I think we'd have to adjust that later on.